### PR TITLE
fix status key

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function status (cb) {
 function statusKey (key, cb) {
   ar.get(key, function (err, feed, content) {
     if (err) return cb(err)
-    if (content && content.length === 0) {
+    if (content && content.length === 0 && metadata.length > 1) {
       return content.update(function () {
         statusKey(key, cb)
       })

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ if (argv.channel) {
             var need = status.need
             var have = status.have
             var progress = (have / need) * 100
-            sendMessage(null, channel, `Status ${key}: need ${need}, have ${have}, %${progress}`)
+            sendMessage(null, channel, `Status ${key}: ${progress.toFixed(2)}% archived (${have} of ${need} blocks)`)
           })
         }
         return status(function (err, msg) {

--- a/index.js
+++ b/index.js
@@ -137,6 +137,11 @@ function status (cb) {
 function statusKey (key, cb) {
   ar.get(key, function (err, feed, content) {
     if (err) return cb(err)
+    if (content && content.length === 0) {
+      return content.update(function () {
+        statusKey(key, cb)
+      })
+    }
     if (!content) content = {length: 0}
     var need = feed.length + content.length
     var have = need - blocksRemain(feed) - blocksRemain(content)


### PR DESCRIPTION
Fixes `!status <key>` to include content blocks always.

Also make it nicer output.